### PR TITLE
- Improvements on get method performance

### DIFF
--- a/src/SparseMatrix/SparseMatrix.cpp
+++ b/src/SparseMatrix/SparseMatrix.cpp
@@ -120,20 +120,21 @@ template<typename T>
 T SparseMatrix<T>::get(int row, int col) const
 {
 	this->validateCoordinates(row, col);
-
 	int currCol;
-
-	for (int pos = this->rows->at(row - 1) - 1; pos < this->rows->at(row) - 1; pos++) {
-		currCol = this->cols->at(pos);
-
+	std::vector<int>& rowsRef = *this->rows;
+	int l1 = rowsRef[row - 1] - 1;
+	int l2 = rowsRef[row] - 1;
+	std::vector<int>& colsRef = *this->cols;
+	std::vector<T>& valsRef = *this->vals;
+	for (int pos = l1; pos < l2; ++pos) {		
+		currCol = colsRef[pos];
 		if (currCol == col) {
-			return this->vals->at(pos);
+			return valsRef[pos];
 
 		} else if (currCol > col) {
 			break;
 		}
 	}
-
 	return T();
 }
 


### PR DESCRIPTION
Hi,

I get some improvements on get access method performance.
In my tests, I used a 1000x1000 matrix and I have made two loops to access each element.

void testInternalAccess(void)
{
    SparseMatrix<double> matrix(1000, 1000);
    fillRandomMatrix(matrix);
    high_resolution_clock::time_point t1 = high_resolution_clock::now();
    for (int row = 1; row <= matrix.getRowCount(); ++row)
    {
        for (int col = 1; col <= matrix.getColumnCount(); ++col)
        {
            matrix.get(row, col);
        }
    }
    high_resolution_clock::time_point t2 = high_resolution_clock::now();
    duration<double> timeSpan = duration_cast<duration<double>>(t2 - t1);
    std::cout << "Access matrix values " << timeSpan.count() << " seconds.\n";
}

Test Results
========
From 5.64532 to 1.22307 seconds. 